### PR TITLE
Notice about OSX 10.6 issue.

### DIFF
--- a/updates/stable/en.json
+++ b/updates/stable/en.json
@@ -8,7 +8,7 @@
         "newFeatures": [
             {
                 "name": "OS X 10.6 Issue",
-                "description": "Do not upgrade if you are running Mac OS X 10.6.x, Sprint 27 fails to load. Newer version of OS X are unaffected by this issue. We hope to fix this bug in Sprint 28. Sorry."
+                "description": "Do not upgrade if you are running Mac OS X 10.6.x, as Sprint 27 fails to load. Newer versions of OS X are unaffected by this issue. We hope to fix this bug in Sprint 28. Sorry."
             },
             {
                 "name": "Save As",


### PR DESCRIPTION
I added an notice about the OSX 10.6 issue to the Sprint 27 notification.
