### PR TITLE
update snow leopard message

### DIFF
--- a/updates/stable/en.json
+++ b/updates/stable/en.json
@@ -7,6 +7,10 @@
         "downloadURL": "http://download.brackets.io",
         "newFeatures": [
             {
+                "name": "OS X 10.6 Issue",
+                "description": "Do not upgrade if you are running Mac OS X 10.6.x, as Sprint 28 fails to load. Newer versions of OS X are unaffected by this issue. We hope to fix this bug in Sprint 29. Sorry."
+            },
+            {
                 "name": "New Untitled Document",
                 "description": "File > New now creates a blank untitled document in memory, as in other text editors; you will be prompted for a filename on save. You can still directly create a new file on disk by choosing New File from the context menu in the file tree."
             },
@@ -33,7 +37,7 @@
         "newFeatures": [
             {
                 "name": "OS X 10.6 Issue",
-                "description": "Do not upgrade if you are running Mac OS X 10.6.x, as Sprint 27 fails to load. Newer versions of OS X are unaffected by this issue. We hope to fix this bug in Sprint 28. Sorry."
+                "description": "Do not upgrade if you are running Mac OS X 10.6.x, as Sprint 27 fails to load. Newer versions of OS X are unaffected by this issue. We hope to fix this bug in Sprint 29. Sorry."
             },
             {
                 "name": "Save As",


### PR DESCRIPTION
@njx or @adrocknaphobia 

After the CEF fire drill we forgot to update the update notifications to include the 10.6 note (thank @gruehle). 3.1453.1279 is the same as sprint 27 and will crash on startup on 10.6. We only had this in english for last sprint and we do not have French or Japanese translations.
