### PR TITLE
Update for sprint-31-hotfix

### DIFF
--- a/updates/stable/en.json
+++ b/updates/stable/en.json
@@ -1,8 +1,8 @@
 [
     {
-        "buildNumber": 9567,
+        "buildNumber": 9569,
         "versionString": "Sprint 31",
-        "dateString": "09-18-2013",
+        "dateString": "09-20-2013",
         "releaseNotesURL": "https://github.com/adobe/brackets/wiki/Release-Notes:-Sprint-31",
         "downloadURL": "http://download.brackets.io",
         "newFeatures": [

--- a/updates/stable/fr.json
+++ b/updates/stable/fr.json
@@ -1,8 +1,8 @@
 [
     {
-        "buildNumber": 9567,
+        "buildNumber": 9569,
         "versionString": "Sprint 31",
-        "dateString": "18-09-2013",
+        "dateString": "20-09-2013",
         "releaseNotesURL": "https://github.com/adobe/brackets/wiki/Release-Notes:-Sprint-31",
         "downloadURL": "http://download.brackets.io",
         "newFeatures": [

--- a/updates/stable/ja.json
+++ b/updates/stable/ja.json
@@ -1,8 +1,8 @@
 [
     {
-        "buildNumber": 9567,
+        "buildNumber": 9569,
         "versionString": "Sprint 31",
-        "dateString": "2013-09-18",
+        "dateString": "2013-09-20",
         "releaseNotesURL": "https://github.com/adobe/brackets/wiki/Release-Notes:-Sprint-31",
         "downloadURL": "http://download.brackets.io",
         "newFeatures": [


### PR DESCRIPTION
Seems like the "sprint-31-hotfix" branch name should get mentioned somewhere, but probably not here. In the Release Notes?
