### PR TITLE
Add undo selection; tweak title for Collapse All

### DIFF
--- a/updates/stable/de.json
+++ b/updates/stable/de.json
@@ -15,7 +15,11 @@
                 "description": "Quickly add the next instance of the current word or range to the multiple selection by typing \u2318B/Ctrl+B, or add all instances with \u2318\u2303G/Alt-F3. Useful for quick renames."
             },
             {
-                "name": "Collapse All File Tree",
+                "name": "Undo/Redo Selection",
+                "description": "Undo the last selection change or edit with \u2318U/Ctrl+U, and redo selections with \u2318\u21E7U/Ctrl+Shift+U. This is useful for correcting a multiple selection mistake or jumping back to a previous selection location."
+            },
+            {
+                "name": "Collapse All Children in File Tree",
                 "description": "Use \u2318\u2325Click/Ctrl+Alt+Click to collapse all children of a folder in the file tree."
             },
             {

--- a/updates/stable/en.json
+++ b/updates/stable/en.json
@@ -15,7 +15,11 @@
                 "description": "Quickly add the next instance of the current word or range to the multiple selection by typing \u2318B/Ctrl+B, or add all instances with \u2318\u2303G/Alt-F3. Useful for quick renames."
             },
             {
-                "name": "Collapse All File Tree",
+                "name": "Undo/Redo Selection",
+                "description": "Undo the last selection change or edit with \u2318U/Ctrl+U, and redo selections with \u2318\u21E7U/Ctrl+Shift+U. This is useful for correcting a multiple selection mistake or jumping back to a previous selection location."
+            },
+            {
+                "name": "Collapse All Children in File Tree",
                 "description": "Use \u2318\u2325Click/Ctrl+Alt+Click to collapse all children of a folder in the file tree."
             },
             {

--- a/updates/stable/es.json
+++ b/updates/stable/es.json
@@ -15,7 +15,11 @@
                 "description": "Quickly add the next instance of the current word or range to the multiple selection by typing \u2318B/Ctrl+B, or add all instances with \u2318\u2303G/Alt-F3. Useful for quick renames."
             },
             {
-                "name": "Collapse All File Tree",
+                "name": "Undo/Redo Selection",
+                "description": "Undo the last selection change or edit with \u2318U/Ctrl+U, and redo selections with \u2318\u21E7U/Ctrl+Shift+U. This is useful for correcting a multiple selection mistake or jumping back to a previous selection location."
+            },
+            {
+                "name": "Collapse All Children in File Tree",
                 "description": "Use \u2318\u2325Click/Ctrl+Alt+Click to collapse all children of a folder in the file tree."
             },
             {

--- a/updates/stable/fr.json
+++ b/updates/stable/fr.json
@@ -15,7 +15,11 @@
                 "description": "Quickly add the next instance of the current word or range to the multiple selection by typing \u2318B/Ctrl+B, or add all instances with \u2318\u2303G/Alt-F3. Useful for quick renames."
             },
             {
-                "name": "Collapse All File Tree",
+                "name": "Undo/Redo Selection",
+                "description": "Undo the last selection change or edit with \u2318U/Ctrl+U, and redo selections with \u2318\u21E7U/Ctrl+Shift+U. This is useful for correcting a multiple selection mistake or jumping back to a previous selection location."
+            },
+            {
+                "name": "Collapse All Children in File Tree",
                 "description": "Use \u2318\u2325Click/Ctrl+Alt+Click to collapse all children of a folder in the file tree."
             },
             {

--- a/updates/stable/ja.json
+++ b/updates/stable/ja.json
@@ -15,7 +15,11 @@
                 "description": "Quickly add the next instance of the current word or range to the multiple selection by typing \u2318B/Ctrl+B, or add all instances with \u2318\u2303G/Alt-F3. Useful for quick renames."
             },
             {
-                "name": "Collapse All File Tree",
+                "name": "Undo/Redo Selection",
+                "description": "Undo the last selection change or edit with \u2318U/Ctrl+U, and redo selections with \u2318\u21E7U/Ctrl+Shift+U. This is useful for correcting a multiple selection mistake or jumping back to a previous selection location."
+            },
+            {
+                "name": "Collapse All Children in File Tree",
                 "description": "Use \u2318\u2325Click/Ctrl+Alt+Click to collapse all children of a folder in the file tree."
             },
             {


### PR DESCRIPTION
- realized we should add a separate entry for Undo Selection since it's useful even apart from multiple selection
- another tweak to title of the Collapse All entry :) - just realized it was misleading to call it Collapse All since it actually collapses the children of a single node, not all nodes (and also re-added the "in", which I think is useful for clarity).

@JeffryBooher - is it too late to get this in for loc?
