### PR TITLE
Properly set up the JSONP file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+GZIPPED-JSONS/

--- a/scripts/create-gzipped-jsons.sh
+++ b/scripts/create-gzipped-jsons.sh
@@ -2,6 +2,7 @@
 
 echo "Create gzipped versions of update notification json files"
 TARGET_DIR="`pwd`/GZIPPED-JSONS"
+platform=`uname -s`
 if [ -e ${TARGET_DIR} ]; then
   rm -r ${TARGET_DIR}
 fi
@@ -11,7 +12,12 @@ mkdir ${TARGET_DIR}
 pushd "../updates/stable" > /dev/null
 
 for json in `ls *.json`; do
-  gzip -k -9 < ${json} > ${TARGET_DIR}/${json}
+  echo "Converting $json ..."
+  if [[ "$platform" == "Darwin" ]]; then # Mac OS X
+    gzip -k -9 < ${json} > ${TARGET_DIR}/${json} # Use the -k option to keep the original file
+  else
+    gzip -9 < ${json} > ${TARGET_DIR}/${json} # Windows/Linux don't have the -k option
+  fi
 done
 
 popd > /dev/null


### PR DESCRIPTION
Currently, the JSONP file requested by http://brackets.io has no callback and can't be executed therefore.
This is being fixed with this PR.

The easier solution would be to set the [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Access-Control-Allow-Origin) header on S3.
