### PR TITLE
Remove leading space

### DIFF
--- a/updates/stable/de.json
+++ b/updates/stable/de.json
@@ -11,7 +11,7 @@
                 "description": "Edit two files side by side or one above the other. Move files between panes using drag & drop across working sets."
             },
             {
-                "name": " Project Tree Improvements",
+                "name": "Project Tree Improvements",
                 "description": "Many bug and performance fixes in the file tree. Notably, it's now possible to right-click files that Brackets cannot open (such as binary files)."
             },
             {

--- a/updates/stable/en.json
+++ b/updates/stable/en.json
@@ -11,7 +11,7 @@
                 "description": "Edit two files side by side or one above the other. Move files between panes using drag & drop across working sets."
             },
             {
-                "name": " Project Tree Improvements",
+                "name": "Project Tree Improvements",
                 "description": "Many bug and performance fixes in the file tree. Notably, it's now possible to right-click files that Brackets cannot open (such as binary files)."
             },
             {

--- a/updates/stable/es.json
+++ b/updates/stable/es.json
@@ -11,7 +11,7 @@
                 "description": "Edit two files side by side or one above the other. Move files between panes using drag & drop across working sets."
             },
             {
-                "name": " Project Tree Improvements",
+                "name": "Project Tree Improvements",
                 "description": "Many bug and performance fixes in the file tree. Notably, it's now possible to right-click files that Brackets cannot open (such as binary files)."
             },
             {


### PR DESCRIPTION
Remove leading space. This is already done in translated versions of fr & ja.
