### PR TITLE
Fix German date format

### DIFF
--- a/updates/stable/de.json
+++ b/updates/stable/de.json
@@ -2,7 +2,7 @@
     {
         "buildNumber": 16898,
         "versionString": "Release 1.7",
-        "dateString": "10-06-2016",
+        "dateString": "10.06.2016",
         "releaseNotesURL": "https://github.com/adobe/brackets/wiki/Release-Notes:-1.7",
         "downloadURL": "http://brackets.io",
         "newFeatures": [
@@ -23,7 +23,7 @@
     {
         "buildNumber": 16680,
         "versionString": "Release 1.6",
-        "dateString": "20-01-2016",
+        "dateString": "20.01.2016",
         "releaseNotesURL": "https://github.com/adobe/brackets/wiki/Release-Notes:-1.6",
         "downloadURL": "http://brackets.io",
         "newFeatures": [


### PR DESCRIPTION
This went unnoticed for the last release, too, so I updated both Release 1.6 and 1.7